### PR TITLE
Fix typo

### DIFF
--- a/doc_source/redis/cluster-create-determine-requirements.md
+++ b/doc_source/redis/cluster-create-determine-requirements.md
@@ -49,7 +49,7 @@ For more information, see [Managing Your ElastiCache Clusters](Clusters.md)\.
 
 ## Scaling Requirements<a name="cluster-create-determine-requirements-scaling"></a>
 
-All clusters can be scaled up by creating a new cluster with the new, larger node type\. When scaling a Redis cluster you can seed if from a backup and avoid having the new cluster start out empty\.
+All clusters can be scaled up by creating a new cluster with the new, larger node type\. When scaling a Redis cluster you can seed it from a backup and avoid having the new cluster start out empty\.
 
 For more information, see [Scaling ElastiCache for Redis Clusters](Scaling.md) in this guide\.
 


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Very small typo fix. `"if" => "it"` in "you can seed it from a backup".


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
