### PR TITLE
Add missing command

### DIFF
--- a/doc_source/redis/applying-updates.md
+++ b/doc_source/redis/applying-updates.md
@@ -114,7 +114,7 @@ After you receive notification that service updates are available, you can inspe
   For more information, see [DescribeServiceUpdates](https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_DescribeServiceUpdates.html)\. 
 + To review update actions that have a `not-applied` or `stopped` status: 
 
-  `aws describe-update-actions --service-update-name sample-service-update --update-action-status not-applied stopped`
+  `aws elasticache describe-update-actions --service-update-name sample-service-update --update-action-status not-applied stopped`
 
   For more information, see [DescribeUpdateActions](https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_DescribeUpdateActions.html)\. 
 + To apply a service update on a list of replication groups: 


### PR DESCRIPTION
*Description of changes:*

#### Before

```sh
% aws describe-update-actions --service-update-name elc-20190604-001 --update-action-status not-applied stopped
usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help
aws: error: argument command: Invalid choice, valid choices are:

# [...]
```

#### After

```sh
% aws elasticache describe-update-actions --service-update-name elc-20190604-001 --update-action-status not-applied stopped
{
    "UpdateActions": []
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
