### PR TITLE
Update modify-replication-group remove n

### DIFF
--- a/doc_source/redis/auth.md
+++ b/doc_source/redis/auth.md
@@ -96,7 +96,7 @@ aws elasticache modify-replication-group \
 --replication-group-id authtestgroup \ 
 --auth-token This-is-the-rotated-token \ 
 --auth-token-update-strategy ROTATE \ 
---apply-immediately n
+--apply-immediately
 ```
 
 For Windows:


### PR DESCRIPTION
I don't think the `n` should follow the `--apply-immediately` flag.

*Issue #, if available:*

*Description of changes:*
- Removed an `n` in a CLI example


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
