### PR TITLE
Change " in contraction to '

### DIFF
--- a/doc_source/redis/elasticache-use-cases.md
+++ b/doc_source/redis/elasticache-use-cases.md
@@ -163,7 +163,7 @@ To send a message to all subscribers to a channel, use the `PUBLISH` command, sp
 PUBLISH news.sports.golf "It's Saturday and sunny. I'm headed to the links."
 ```
 
-A client can"t publish to a channel that it's subscribed to\.
+A client can't publish to a channel that it's subscribed to\.
 
 For more information, see [Pub/Sub](http://redis.io/topics/pubsub) in the Redis documentation\.
 


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Change `can"t` (introduced in [5b28e27](https://github.com/awsdocs/amazon-elasticache-docs/commit/5b28e270f75cfe126d4078b4ccd4d2b1fa22071b#diff-68001a90f8dc437d3d1e2de0afecf6c4R166)) to `can't`

I made the change in the GitHub web editor, changing only [l. 166](https://github.com/awsdocs/amazon-elasticache-docs/pull/24/files#diff-68001a90f8dc437d3d1e2de0afecf6c4R166); AFAIK I didn't touch the EOF 🤷 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
