### PR TITLE
Update in-transit-encryption cat command

### DIFF
--- a/doc_source/redis/in-transit-encryption.md
+++ b/doc_source/redis/in-transit-encryption.md
@@ -176,7 +176,7 @@ To work around this, you can use the `stunnel` command to create an SSL tunnel t
 1. Run the following command to create and edit file `'/etc/stunnel/redis-cli.conf'` simultaneously to add a ElastiCache for Redis cluster endpoint to one or more connection parameters, using provided output below as template:\.
 
    ```
-   cat /etc/stunnel/redis-cli.conf
+   cat >/etc/stunnel/redis-cli.conf <<EOL
    				
    fips = no
    setuid = root
@@ -194,6 +194,7 @@ To work around this, you can use the `stunnel` command to create an SSL tunnel t
       client = yes
       accept = 127.0.0.1:6380
       connect = ssltest-02.ssltest.wif01h.use1.cache.amazonaws.com:6379
+   EOL
    ```
 
    In this example, the config file has two connections, the `redis-cli` and the `redis-cli-replica`\. The parameters are set as follows:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
-The cat command won't work as 'copy-paste' unless the redirect and multiline operators are specified.
-Reviewers can try local with any file to verify if command is working as intended.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
