### PR TITLE
Added a title for the See Also cluster based RBAC link

### DIFF
--- a/doc_source/redis/in-transit-encryption.md
+++ b/doc_source/redis/in-transit-encryption.md
@@ -270,6 +270,6 @@ To work around this, you can use the `stunnel` command to create an SSL tunnel t
 ## See Also<a name="in-transit-encryption-see-also"></a>
 + [At\-Rest Encryption in ElastiCache for Redis](at-rest-encryption.md)
 + [Authenticating Users with the Redis AUTH Command](auth.md)
-+ [](Clusters.RBAC.md)
++ [Authenticating Users with Role-Based Access Control (RBAC)](Clusters.RBAC.md)
 + [Amazon VPCs and ElastiCache Security](VPCs.md)
 + [Identity and Access Management in Amazon ElastiCache](IAM.md)


### PR DESCRIPTION
*Description of changes:*

That link was missing a title, so it was an empty bullet point.  This change should make that link visible and clickable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
