### PR TITLE
Im prove tip on redis modes

### DIFF
--- a/doc_source/redis/redis-cluster-resharding-online.md
+++ b/doc_source/redis/redis-cluster-resharding-online.md
@@ -49,7 +49,7 @@ You can use the AWS Management Console to add one or more shards to your Redis \
 
 1. Locate and choose the name, not the box to the left of the cluster's name, of the Redis \(cluster mode enabled\) cluster that you want to add shards to\.
 **Tip**  
-Redis \(cluster mode enabled\) clusters have a value of 1 or greater in the **Shards** column\.
+Redis \(cluster mode enabled\) clusters show 'Clustered Redis' in the **Mode** column\.
 
 1. Choose **Add shard**\.
 


### PR DESCRIPTION
The previous version of the tip could imply that you can see if a Redis cluster has cluster mode enabled by looking at the number of shards. This is not true since Redis (cluster mode disabled) clusters with read replicas also show a shard count of 1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
