### PR TITLE
add missing param on linux example

### DIFF
--- a/doc_source/redis/auth.md
+++ b/doc_source/redis/auth.md
@@ -178,6 +178,7 @@ If you are authenticating users with Redis Role\-Based Access Control \(RBAC\) a
   aws elasticache modify-replication-group \
       --replication-group-id test \
       --remove-user-groups \
+      --auth-token password \
       --auth-token-update-strategy SET \ 
       --apply-immediately
   ```


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Add `--auth-token password` required parameter to the Linux example of how to migrate to REDIS AUTH from RBAC.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
