### PR TITLE
Edit accessing-elasticache.md

### DIFF
--- a/doc_source/redis/accessing-elasticache.md
+++ b/doc_source/redis/accessing-elasticache.md
@@ -203,7 +203,7 @@ It is possible to create a Certificate Authority \(CA\) using different techniqu
   + Select **Review and import**\.
   + Select **Import**\.
 
-  To submit the server's certificates to ACM using the AWS CLI, run the following command: `aws acm import-certificate --certificate fileb://easy-rsa/pki/issued/server.crt --private-key file://easy-rsa/pki/private/server.key --certificate-chain file://easy-rsa/pki/ca.crt --region region`
+  To submit the server's certificates to ACM using the AWS CLI, run the following command: `aws acm import-certificate --certificate fileb://easy-rsa/pki/issued/server.crt --private-key fileb://easy-rsa/pki/private/server.key --certificate-chain fileb://easy-rsa/pki/ca.crt --region region`
 
   Note the Certificate ARN for future use\.
 


### PR DESCRIPTION
### Issue:
`aws acm import-certificate` is not working. It returns an error from `--private-key file://easy-rsa/pki/private/server.key`.

### Description of changes:
I was trying to execute the command to import certificate to ACM. But it returned an error from `--private-key file://easy-rsa/pki/private/server.key`. The issue was in the command it was `file://` instead of `fileb://`. Once I replace both `--private-key file://` and `--certificate-chain file://` with `fileb://` the command worked.

**ERROR:**
```
romina@Rominas-MacBook-Pro % aws acm import-certificate --certificate fileb://easy-rsa/pki/issued/server.crt --private-key file://easy-rsa/pki/private/server.key --certificate-chain file://easy-rsa/pki/ca.crt --region us-west-2

Invalid base64: "-----BEGIN PRIVATE KEY-----
XXXXXXXX
-----END PRIVATE KEY-----
"
```

**FIX:**
```
romina@Rominas-MacBook-Pro % aws acm import-certificate --certificate fileb://easy-rsa/pki/issued/server.crt --private-key fileb://easy-rsa/pki/private/server.key --certificate-chain fileb://easy-rsa/pki/ca.crt --region us-west-2
{
    "CertificateArn": "arn:aws:acm:us-west-2:XXX:certificate/XXX"
}
```

_PS: I was executing the command on macOS_


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
