### PR TITLE
Fixit easier copy and paste

### DIFF
--- a/doc_source/memcache/Appendix.PHPAutoDiscoverySetup.Installing.md
+++ b/doc_source/memcache/Appendix.PHPAutoDiscoverySetup.Installing.md
@@ -33,21 +33,21 @@ Replace *PHP\-7\.x* with the version you are using\.
 
    1. If not installed, use the following command to install:
 
-       `sudo yum install -y amazon-linux-extras ` 
+       `sudo yum install -y amazon-linux-extras `
 
    1. Confirm that PHP 7\.x topic is available in the Amazon Linux 2 machine:
 
-       `sudo amazon-linux-extras | grep php ` 
+       `sudo amazon-linux-extras | grep php `
 
    1. From the output, review all PHP 7 topics and select the version you want:
 
-       `sudo amazon-linux-extras enable php7.x ` 
+       `sudo amazon-linux-extras enable php7.x `
 
    1. Install PHP packages from the repository\. For example:
 
        `sudo yum clean metadata`
 
-      `sudo yum install php php-devel ` 
+      `sudo yum install php php-devel `
 
 1. Download the Amazon ElastiCache Cluster Client\.
    + Open the ElastiCache console at [https://console\.aws\.amazon\.com/elasticache/](https://console.aws.amazon.com/elasticache/)\.
@@ -187,7 +187,7 @@ Replace *php7\.x* with the version you are using\.
 1. Install PHP dependencies:
 
    ```
-   $ sudo yum install gcc-c++ php php-pear
+   sudo yum install gcc-c++ php php-pear
    ```
 
 1. Download the correct `php-memcached` package for your Amazon EC2 instance and PHP version\. For more information, see [Downloading the installation package](Appendix.PHPAutoDiscoverySetup.Downloading.md)\.
@@ -195,21 +195,21 @@ Replace *php7\.x* with the version you are using\.
 1. Install `php-memcached`\. The URI should be the download path for the installation package:
 
    ```
-   $ sudo pecl install <package download path>
+   sudo pecl install <package download path>
    ```
 
    Here is a sample installation command for PHP 5\.4, 64\-bit Linux\. In this sample, replace *X\.Y\.Z* with the actual version number:
 
    ```
-   $ sudo pecl install /home/AmazonElastiCacheClusterClient-X.Y.Z-PHP54-64bit.tgz
+   sudo pecl install /home/AmazonElastiCacheClusterClient-X.Y.Z-PHP54-64bit.tgz
    ```
-**Note**  
+**Note**
 Be sure to use the latest version of the install artifact\.
 
-1. With root/sudo permission, add a new file named `memcached.ini` in the `/etc/php.d` directory, and insert "extension=amazon\-elasticache\-cluster\-client\.so" in the file: 
+1. With root/sudo permission, add a new file named `memcached.ini` in the `/etc/php.d` directory, and insert "extension=amazon\-elasticache\-cluster\-client\.so" in the file:
 
    ```
-   $ echo "extension=amazon-elasticache-cluster-client.so" | sudo tee --append /etc/php.d/memcached.ini
+   echo "extension=amazon-elasticache-cluster-client.so" | sudo tee --append /etc/php.d/memcached.ini
    ```
 
 1. Start or restart your Apache server\.
@@ -259,31 +259,31 @@ Be sure to use the latest version of the install artifact\.
 1. Install PHP dependencies:
 
    ```
-   sudo apt-get update 
+   sudo apt-get update
    sudo apt-get install gcc g++ php5 php-pear
    ```
 
-1. Download the correct `php-memcached` package for your Amazon EC2 instance and PHP version\. For more information, see [Downloading the installation package](Appendix.PHPAutoDiscoverySetup.Downloading.md)\. 
+1. Download the correct `php-memcached` package for your Amazon EC2 instance and PHP version\. For more information, see [Downloading the installation package](Appendix.PHPAutoDiscoverySetup.Downloading.md)\.
 
-1. Install `php-memcached`\. The URI should be the download path for the installation package\. 
+1. Install `php-memcached`\. The URI should be the download path for the installation package\.
 
    ```
-   $ sudo pecl install <package download path>
+   sudo pecl install <package download path>
    ```
-**Note**  
-This installation step installs the build artifact `amazon-elasticache-cluster-client.so` into the `/usr/lib/php5/20121212*` directory\. Verify the absolute path of the build artifact, because you need it in the next step\. 
+**Note**
+This installation step installs the build artifact `amazon-elasticache-cluster-client.so` into the `/usr/lib/php5/20121212*` directory\. Verify the absolute path of the build artifact, because you need it in the next step\.
 
    If the previous command doesn't work, you need to manually extract the PHP client artifact `amazon-elasticache-cluster-client.so` from the downloaded `*.tgz` file, and copy it to the `/usr/lib/php5/20121212*` directory\.
 
    ```
-   $ tar -xvf <package download path>
+   tar -xvf <package download path>
    cp amazon-elasticache-cluster-client.so /usr/lib/php5/20121212/
    ```
 
 1. With root/sudo permission, add a new file named `memcached.ini` in the `/etc/php5/cli/conf.d` directory, and insert "extension=<absolute path to amazon\-elasticache\-cluster\-client\.so>" in the file\.
 
    ```
-   $ echo "extension=<absolute path to amazon-elasticache-cluster-client.so>" | sudo tee --append /etc/php5/cli/conf.d/memcached.ini
+   echo "extension=<absolute path to amazon-elasticache-cluster-client.so>" | sudo tee --append /etc/php5/cli/conf.d/memcached.ini
    ```
 
 1. Start or restart your Apache server\.
@@ -296,26 +296,26 @@ This installation step installs the build artifact `amazon-elasticache-cluster-c
 
 ### To install PHP 5 for SUSE Linux enterprise server 11 AMI \(64\-bit or 32\-bit\)<a name="Appendix.PHPAutoDiscoverySetup.Installing.PHP5x.SuseLinux"></a>
 
-1. Launch a SUSE Linux instance \(either 64\-bit or 32\-bit\) and log into it\. 
+1. Launch a SUSE Linux instance \(either 64\-bit or 32\-bit\) and log into it\.
 
 1. Install PHP dependencies:
 
    ```
-   $ sudo zypper install gcc php53-devel
+   sudo zypper install gcc php53-devel
    ```
 
-1. Download the correct `php-memcached` package for your Amazon EC2 instance and PHP version\. For more information, see [Downloading the installation package](Appendix.PHPAutoDiscoverySetup.Downloading.md)\. 
+1. Download the correct `php-memcached` package for your Amazon EC2 instance and PHP version\. For more information, see [Downloading the installation package](Appendix.PHPAutoDiscoverySetup.Downloading.md)\.
 
-1. Install `php-memcached`\. The URI should be the download path for the installation package\. 
+1. Install `php-memcached`\. The URI should be the download path for the installation package\.
 
    ```
-   $ sudo pecl install <package download path>
+   sudo pecl install <package download path>
    ```
 
 1. With root/sudo permission, add a new file named `memcached.ini` in the `/etc/php5/conf.d` directory, and insert **extension=`amazon-elasticache-cluster-client.so`** in the file\.
 
    ```
-   $ echo "extension=amazon-elasticache-cluster-client.so" | sudo tee --append /etc/php5/conf.d/memcached.ini
+   echo "extension=amazon-elasticache-cluster-client.so" | sudo tee --append /etc/php5/conf.d/memcached.ini
    ```
 
 1. Start or restart your Apache server\.
@@ -324,8 +324,8 @@ This installation step installs the build artifact `amazon-elasticache-cluster-c
    sudo /etc/init.d/httpd start
    ```
 
-**Note**  
-If Step 5 doesn't work for any of the previous platforms, verify the install path for `amazon-elasticache-cluster-client.so`\. Also, specify the full path of the binary in the extension\. In addition, verify that the PHP in use is a supported version\. We support versions 5\.3 through 5\.5\. 
+**Note**
+If Step 5 doesn't work for any of the previous platforms, verify the install path for `amazon-elasticache-cluster-client.so`\. Also, specify the full path of the binary in the extension\. In addition, verify that the PHP in use is a supported version\. We support versions 5\.3 through 5\.5\.
 
  
 
@@ -335,5 +335,5 @@ On some systems, notably CentOS7 and Red Hat Enterprise Linux \(RHEL\) 7\.1, `li
 
 ```
 cd /usr/lib64
-$ sudo ln libsasl2.so.3 libsasl2.so.2
+sudo ln libsasl2.so.3 libsasl2.so.2
 ```

--- a/doc_source/redis/GettingStarted.ConnectToCacheNode.md
+++ b/doc_source/redis/GettingStarted.ConnectToCacheNode.md
@@ -98,7 +98,7 @@ This process covers testing a connection using redis\-cli utility for unplanned 
 
    Amazon Linux 2
 
-   ```bash
+   ```console
    sudo amazon-linux-extras install epel -y
    sudo yum install gcc jemalloc-devel openssl-devel tcl tcl-devel -y
    sudo wget http://download.redis.io/redis-stable.tar.gz

--- a/doc_source/redis/GettingStarted.ConnectToCacheNode.md
+++ b/doc_source/redis/GettingStarted.ConnectToCacheNode.md
@@ -98,7 +98,7 @@ This process covers testing a connection using redis\-cli utility for unplanned 
 
    Amazon Linux 2
 
-   ```console
+   ```
    sudo amazon-linux-extras install epel -y
    sudo yum install gcc jemalloc-devel openssl-devel tcl tcl-devel -y
    sudo wget http://download.redis.io/redis-stable.tar.gz
@@ -110,11 +110,11 @@ This process covers testing a connection using redis\-cli utility for unplanned 
    Amazon Linux
 
    ```
-   $sudo yum install gcc jemalloc-devel openssl-devel tcl tcl-devel clang wget
-   $sudo wget http://download.redis.io/redis-stable.tar.gz
-   $sudo tar xvzf redis-stable.tar.gz
-   $cd redis-stable
-   $sudo CC=clang make BUILD_TLS=yes
+   sudo yum install gcc jemalloc-devel openssl-devel tcl tcl-devel clang wget
+   sudo wget http://download.redis.io/redis-stable.tar.gz
+   sudo tar xvzf redis-stable.tar.gz
+   cd redis-stable
+   sudo CC=clang make BUILD_TLS=yes
    ```
 **Note**
 If the cluster you are connecting to isn't encrypted, you don't need the `Build_TLS=yes` option\.

--- a/doc_source/redis/GettingStarted.ConnectToCacheNode.md
+++ b/doc_source/redis/GettingStarted.ConnectToCacheNode.md
@@ -2,9 +2,9 @@
 
 Before you continue, complete [Step 3: Authorize access to the cluster](GettingStarted.AuthorizeAccess.md)\.
 
-This section assumes that you've created an Amazon EC2 instance and can connect to it\. For instructions on how to do this, see the [Amazon EC2 Getting Started Guide](https://docs.aws.amazon.com/AWSEC2/latest/GettingStartedGuide/)\. 
+This section assumes that you've created an Amazon EC2 instance and can connect to it\. For instructions on how to do this, see the [Amazon EC2 Getting Started Guide](https://docs.aws.amazon.com/AWSEC2/latest/GettingStartedGuide/)\.
 
-An Amazon EC2 instance can connect to a cluster node only if you have authorized it to do so\. 
+An Amazon EC2 instance can connect to a cluster node only if you have authorized it to do so\.
 
 ## Find your node endpoints<a name="GettingStarted.FindEndpoints"></a>
 
@@ -16,9 +16,9 @@ If a Redis \(cluster mode disabled\) cluster has only one node, the node's endpo
 
 The primary endpoint is a DNS name that always resolves to the primary node in the cluster\. The primary endpoint is immune to changes to your cluster, such as promoting a read replica to the primary role\. For write activity, we recommend that your applications connect to the primary endpoint instead of connecting directly to the primary\.
 
-A reader endpoint will evenly split incoming connections to the endpoint between all read replicas in a ElastiCache for Redis cluster\. Additional factors such as when the application creates the connections or how the application \(re\)\-uses the connections will determine the traffic distribution\. Reader endpoints keep up with cluster changes in real\-time as replicas are added or removed\. You can place your ElastiCache for Redis cluster’s multiple read replicas in different AWS Availability Zones \(AZ\) to ensure high availability of reader endpoints\. 
+A reader endpoint will evenly split incoming connections to the endpoint between all read replicas in a ElastiCache for Redis cluster\. Additional factors such as when the application creates the connections or how the application \(re\)\-uses the connections will determine the traffic distribution\. Reader endpoints keep up with cluster changes in real\-time as replicas are added or removed\. You can place your ElastiCache for Redis cluster’s multiple read replicas in different AWS Availability Zones \(AZ\) to ensure high availability of reader endpoints\.
 
-**Note**  
+**Note**
 A reader endpoint is not a load balancer\. It is a DNS record that will resolve to an IP address of one of the replica nodes in a round robin fashion\.
 
 For read activity, applications can also connect to any node in the cluster\. Unlike the primary endpoint, node endpoints resolve to specific endpoints\. If you make a change in your cluster, such as adding or deleting a replica, you must update the node endpoints in your application\.
@@ -31,7 +31,7 @@ For read activity, applications can also connect to any node in the cluster\. Un
 
    The clusters screen will appear with a list of Redis \(cluster mode disabled\) and Redis \(cluster mode enabled\) clusters\. Choose the cluster you created in the [Creating a Redis \(cluster mode disabled\) cluster \(Console\)](GettingStarted.CreateCluster.md#Clusters.Create.CON.Redis-gs) section\.
 
-1. To find the cluster's Primary and/or Reader endpoints, choose the box to the left of cluster's name\.  
+1. To find the cluster's Primary and/or Reader endpoints, choose the box to the left of cluster's name\.
 ![\[Image: Primary endpoint for a Redis (cluster mode disabled) cluster\]](http://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/images/Reader-Endpoint.png)
 
    *Primary and Reader endpoints for a Redis \(cluster mode disabled\) cluster*
@@ -40,7 +40,7 @@ For read activity, applications can also connect to any node in the cluster\. Un
 
 1. If the Redis \(cluster mode disabled\) cluster has replica nodes, you can find the cluster's replica node endpoints by choosing the cluster's name\.
 
-   The nodes screen appears with each node in the cluster, primary and replicas, listed with its endpoint\.  
+   The nodes screen appears with each node in the cluster, primary and replicas, listed with its endpoint\.
 ![\[Image: Node endpoints for a Redis (cluster mode disabled) cluster\]](http://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/images/ElastiCache-Endpoints-Redis-Node.png)
 
    *Node endpoints for a Redis \(cluster mode disabled\) cluster*
@@ -59,7 +59,7 @@ A Redis \(cluster mode disabled\) primary endpoint looks something like the foll
 
 ```
 clusterName.xxxxxx.nodeId.regionAndAz.cache.amazonaws.com:port
-			
+
 redis-01.7abc2d.0001.usw2.cache.amazonaws.com:6379
 ```
 
@@ -71,9 +71,9 @@ master.clusterName.xxxxxx.regionAndAz.cache.amazonaws.com:port
 master.ncit.ameaqx.use1.cache.amazonaws.com:6379
 ```
 
-Now that you have the endpoint you need, copy it to your clipboard for use in connecting to the cluster in the next step\. 
+Now that you have the endpoint you need, copy it to your clipboard for use in connecting to the cluster in the next step\.
 
-To further explore how to find your endpoints, see the relevant topics for the engine and cluster type you're running\. 
+To further explore how to find your endpoints, see the relevant topics for the engine and cluster type you're running\.
 + [Finding connection endpoints](Endpoints.md)
 + [Finding Endpoints for a Redis \(Cluster Mode Enabled\) Cluster \(Console\)](Endpoints.md#Endpoints.Find.RedisCluster)—You need the cluster's Configuration endpoint\.
 + [Finding Endpoints \(AWS CLI\)](Endpoints.md#Endpoints.Find.CLI)
@@ -85,26 +85,26 @@ Now that you have the endpoint you need, you can log in to an EC2 instance and c
 
 The following example uses Amazon EC2 instances running Amazon Linux and Amazon Linux 2\. For details on installing and compiling redis\-cli with other Linux distributions, see the documentation for your specific operating system\.\.
 
-**Note**  
+**Note**
 This process covers testing a connection using redis\-cli utility for unplanned use only\. For a list of supported Redis clients, see the [Redis documentation](https://redis.io/)\. For examples of using the AWS SDKs with ElastiCache, see [Getting Started with ElastiCache and AWS SDKs](ElastiCache-Getting-Started-Tutorials.md)\.
 
 ### Download and install redis\-cli<a name="Download-and-install-redis-cli"></a>
 
 
 
-1. Connect to your Amazon EC2 instance using the connection utility of your choice\. For instructions on how to connect to an Amazon EC2 instance, see the [Amazon EC2 Getting Started Guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EC2_GetStarted.html)\. 
+1. Connect to your Amazon EC2 instance using the connection utility of your choice\. For instructions on how to connect to an Amazon EC2 instance, see the [Amazon EC2 Getting Started Guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EC2_GetStarted.html)\.
 
 1. Download and install redis\-cli utility by running following commands:
 
    Amazon Linux 2
 
-   ```
-   $sudo amazon-linux-extras install epel -y
-   $sudo yum install gcc jemalloc-devel openssl-devel tcl tcl-devel -y
-   $sudo wget http://download.redis.io/redis-stable.tar.gz
-   $sudo tar xvzf redis-stable.tar.gz
-   $cd redis-stable
-   $sudo make BUILD_TLS=yes
+   ```bash
+   sudo amazon-linux-extras install epel -y
+   sudo yum install gcc jemalloc-devel openssl-devel tcl tcl-devel -y
+   sudo wget http://download.redis.io/redis-stable.tar.gz
+   sudo tar xvzf redis-stable.tar.gz
+   cd redis-stable
+   sudo make BUILD_TLS=yes
    ```
 
    Amazon Linux
@@ -116,7 +116,7 @@ This process covers testing a connection using redis\-cli utility for unplanned 
    $cd redis-stable
    $sudo CC=clang make BUILD_TLS=yes
    ```
-**Note**  
+**Note**
 If the cluster you are connecting to isn't encrypted, you don't need the `Build_TLS=yes` option\.
 
 ### Connecting to a cluster mode disabled unencrypted\-cluster<a name="Connecting-to-a-cluster-mode-disabled-unencrypted-cluster"></a>
@@ -126,7 +126,7 @@ If the cluster you are connecting to isn't encrypted, you don't need the `Build_
    ```
    src/redis-cli -h cluster-endpoint -c -p port number
    ```
-**Note**  
+**Note**
 In the preceding command, option \-c enables cluster mode following [\-ASK and \-MOVED redirections](https://redis.io/topics/cluster-spec)\.
 
    The result in a Redis command prompt looks similar to the following:
@@ -159,12 +159,12 @@ In the preceding command, option \-c enables cluster mode following [\-ASK and \
 
 By default, redis\-cli uses an unencrypted TCP connection when connecting to Redis\. The option `BUILD_TLS=yes` enables SSL/TLS at the time of redis\-cli compilation as shown in the preceding [Download and install redis\-cli](#Download-and-install-redis-cli) section\. Enabling AUTH is optional\. However, you must enable encryption in\-transit in order to enable AUTH\. For more details on ElastiCache encryption and authentication, see [ElastiCache for Redis in\-transit encryption \(TLS\)](in-transit-encryption.md)\.
 
-**Note**  
+**Note**
 You can use the option `--tls` with redis\-cli to connect to both cluster mode enabled and disabled encrypted clusters\. If a cluster has an AUTH token set, then you can use the option `-a` to provide an AUTH password\.
 
 In the following examples, be sure to replace *cluster\-endpoint* and *port number* with the endpoint of your cluster and your port number\. \(The default port for Redis is 6379\.\)
 
-**Connect to cluster mode disabled encrypted clusters** 
+**Connect to cluster mode disabled encrypted clusters**
 
 The following example connects to an encryption and authentication enabled cluster:
 
@@ -178,7 +178,7 @@ The following example connects to a cluster that has only encryption enabled:
 src/redis-cli -h cluster-endpoint --tls -p port number
 ```
 
-**Connect to cluster mode enabled encrypted clusters** 
+**Connect to cluster mode enabled encrypted clusters**
 
 The following example connects to an encryption and authentication enabled cluster:
 
@@ -224,7 +224,7 @@ In the following example, you use the *redis\-cli* utility to connect to a clust
 
 **To connect to a Redis cluster that is not encryption\-enabled using *redis\-cli***
 
-1. Connect to your Amazon EC2 instance using the connection utility of your choice\. For instructions on how to connect to an Amazon EC2 instance, see the [Amazon EC2 Getting Started Guide](https://docs.aws.amazon.com/AWSEC2/latest/GettingStartedGuide/)\. 
+1. Connect to your Amazon EC2 instance using the connection utility of your choice\. For instructions on how to connect to an Amazon EC2 instance, see the [Amazon EC2 Getting Started Guide](https://docs.aws.amazon.com/AWSEC2/latest/GettingStartedGuide/)\.
 
 1. Copy and paste the link [https://github.com/microsoftarchive/redis/releases/download/win-3.0.504/Redis-x64-3.0.504.zip](https://github.com/microsoftarchive/redis/releases/download/win-3.0.504/Redis-x64-3.0.504.zip) in an Internet browser to download the zip file for the Redis client from the available release at GitHub [https://github.com/microsoftarchive/redis/releases/tag/win-3.0.504](https://github.com/microsoftarchive/redis/releases/tag/win-3.0.504)
 
@@ -248,7 +248,7 @@ In the following example, you use the *redis\-cli* utility to connect to a clust
    get a                  // Get value for key "a"
    "hello"
    get b                  // Get value for key "b" results in miss
-   (nil)				
+   (nil)
    set b "Good-bye" EX 5  // Set key "b" with a string value and a 5 second expiration
    "Good-bye"
    get b                  // Get value for key "b"
@@ -266,7 +266,7 @@ In the following example, you use the *redis\-cli* utility to connect to a clust
    ```
    src/redis-cli -h cluster-endpoint -c -p port number
    ```
-**Note**  
+**Note**
 In the preceding command, option \-c enables cluster mode following [\-ASK and \-MOVED redirections](https://redis.io/topics/cluster-spec)\.
 
    The result in a Redis command prompt looks similar to the following:
@@ -299,12 +299,12 @@ In the preceding command, option \-c enables cluster mode following [\-ASK and \
 
 By default, redis\-cli uses an unencrypted TCP connection when connecting to Redis\. The option `BUILD_TLS=yes` enables SSL/TLS at the time of redis\-cli compilation as shown in the preceding [Download and install redis\-cli](#Download-and-install-redis-cli) section\. Enabling AUTH is optional\. However, you must enable encryption in\-transit in order to enable AUTH\. For more details on ElastiCache encryption and authentication, see [ElastiCache for Redis in\-transit encryption \(TLS\)](in-transit-encryption.md)\.
 
-**Note**  
+**Note**
 You can use the option `--tls` with redis\-cli to connect to both cluster mode enabled and disabled encrypted clusters\. If a cluster has an AUTH token set, then you can use the option `-a` to provide an AUTH password\.
 
 In the following examples, be sure to replace *cluster\-endpoint* and *port number* with the endpoint of your cluster and your port number\. \(The default port for Redis is 6379\.\)
 
-**Connect to cluster mode disabled encrypted clusters** 
+**Connect to cluster mode disabled encrypted clusters**
 
 The following example connects to an encryption and authentication enabled cluster:
 
@@ -318,7 +318,7 @@ The following example connects to a cluster that has only encryption enabled:
 src/redis-cli -h cluster-endpoint --tls -p port number
 ```
 
-**Connect to cluster mode enabled encrypted clusters** 
+**Connect to cluster mode enabled encrypted clusters**
 
 The following example connects to an encryption and authentication enabled cluster:
 

--- a/doc_source/redis/in-transit-encryption.md
+++ b/doc_source/redis/in-transit-encryption.md
@@ -4,7 +4,7 @@ To help keep your data secure, Amazon ElastiCache and Amazon EC2 provide mechani
 
 In\-transit encryption is optional and can only be enabled on Redis replication groups when they are created\. You enable in\-transit encryption on a replication group by setting the parameter `TransitEncryptionEnabled` to `true` \(CLI: `--transit-encryption-enabled`\) when you create the replication group\. You can do this whether you are creating the replication group using the AWS Management Console, the AWS CLI, or the ElastiCache API\. If you enable in\-transit encryption, you must also provide a value for `CacheSubnetGroup`\.
 
-**Important**  
+**Important**
 The parameters `TransitEncryptionEnabled` \(CLI: `--transit-encryption-enabled`\) are only available when using the `CreateReplicationGroup` \(CLI: `create-replication-group`\) operation\.
 
 **Topics**
@@ -42,7 +42,7 @@ The following constraints on Amazon ElastiCache in\-transit encryption should be
 
 Because of the processing required to encrypt and decrypt the data at the endpoints, implementing in\-transit encryption can reduce performance\. Benchmark in\-transit encryption compared to no encryption on your own data to determine its impact on performance for your implementation\.
 
-**Tip**  
+**Tip**
 Because creating new connections can be expensive, you can reduce the performance impact of in\-transit encryption by persisting your SSL connections\.
 
 ## Enabling in\-transit encryption<a name="in-transit-encryption-enable"></a>
@@ -64,7 +64,7 @@ You can only enable in\-transit encryption when you create a Redis replication g
 1. Update the endpoints in your application to the new replication group's endpoints\. For more information, see [Finding connection endpoints](Endpoints.md)\.
 
 1. Delete the old replication group\. For more information, see the following:
-   + [Deleting a cluster](Clusters.Delete.md) 
+   + [Deleting a cluster](Clusters.Delete.md)
    + [Deleting a replication group](Replication.DeletingRepGroup.md)
 
  
@@ -114,7 +114,7 @@ Use the AWS CLI operation `create-replication-group` and the following parameter
     **\-\-replicas\-per\-node\-group**—Specifies the number of replica nodes in each node group\. The value specified here is applied to all shards in this replication group\. The maximum value of this parameter is 5\.
   + **\-\-node\-group\-configuration**—Specifies the configuration of each shard independently\.
 
-  
+
 
 For more information, see the following:
 + [Creating a Redis \(Cluster Mode Enabled\) replication group from scratch \(AWS CLI\)](Replication.CreatingReplGroup.NoExistingCluster.Cluster.md#Replication.CreatingReplGroup.NoExistingCluster.Cluster.CLI)
@@ -158,7 +158,7 @@ Use the ElastiCache API operation `CreateReplicationGroup` and the following par
     **ReplicasPerNodeGroup**—Specifies the number of replica nodes in each node group\. The value specified here is applied to all shards in this replication group\. The maximum value of this parameter is 5\.
   + **NodeGroupConfiguration**—Specifies the configuration of each shard independently\.
 
-  
+
 
 For more information, see the following:
 + [Creating a replication group in Redis \(Cluster Mode Enabled\) from scratch \(ElastiCache API\)](Replication.CreatingReplGroup.NoExistingCluster.Cluster.md#Replication.CreatingReplGroup.NoExistingCluster.Cluster.API)
@@ -168,7 +168,7 @@ For more information, see the following:
 
 
 
-To access data from ElastiCache for Redis nodes enabled with in\-transit encryption, you use clients that work with Secure Socket Layer \(SSL\)\. You can also use redis\-cli with TLS/SSL on Amazon linux and Amazon Linux 2\. 
+To access data from ElastiCache for Redis nodes enabled with in\-transit encryption, you use clients that work with Secure Socket Layer \(SSL\)\. You can also use redis\-cli with TLS/SSL on Amazon linux and Amazon Linux 2\.
 
 **To use redis\-cli to connect to a Redis cluster enabled with in\-transit encryption on Amazon Linux 2 or Amazon Linux**
 
@@ -179,24 +179,24 @@ To access data from ElastiCache for Redis nodes enabled with in\-transit encrypt
    Amazon Linux 2
 
    ```
-   $ sudo yum -y install openssl-devel gcc
-   $ wget http://download.redis.io/redis-stable.tar.gz
-   $ tar xvzf redis-stable.tar.gz
-   $ cd redis-stable
-   $ make distclean
-   $ make redis-cli BUILD_TLS=yes
-   $ sudo install -m 755 src/redis-cli /usr/local/bin/
+   sudo yum -y install openssl-devel gcc
+   wget http://download.redis.io/redis-stable.tar.gz
+   tar xvzf redis-stable.tar.gz
+   cd redis-stable
+   make distclean
+   make redis-cli BUILD_TLS=yes
+   sudo install -m 755 src/redis-cli /usr/local/bin/
    ```
 
    Amazon Linux
 
    ```
-   $ sudo yum install gcc jemalloc-devel openssl-devel tcl tcl-devel clang wget
-   $ wget http://download.redis.io/redis-stable.tar.gz
-   $ tar xvzf redis-stable.tar.gz
-   $ cd redis-stable
-   $ make redis-cli CC=clang BUILD_TLS=yes
-   $ sudo install -m 755 src/redis-cli /usr/local/bin/
+   sudo yum install gcc jemalloc-devel openssl-devel tcl tcl-devel clang wget
+   wget http://download.redis.io/redis-stable.tar.gz
+   tar xvzf redis-stable.tar.gz
+   cd redis-stable
+   make redis-cli CC=clang BUILD_TLS=yes
+   sudo install -m 755 src/redis-cli /usr/local/bin/
    ```
 
    On Amazon Linux, you may also need to run the following additional steps:
@@ -237,13 +237,13 @@ To work around this, you can use the `stunnel` command to create an SSL tunnel t
 
    ```
    vi /etc/stunnel/redis-cli.conf
-   
-   				
+
+
    fips = no
    setuid = root
    setgid = root
    pid = /var/run/stunnel.pid
-   debug = 7 
+   debug = 7
    delay = yes
    options = NO_SSLv2
    options = NO_SSLv3
@@ -272,19 +272,19 @@ To work around this, you can use the `stunnel` command to create an SSL tunnel t
 
    ```
    sudo netstat -tulnp | grep -i stunnel
-   				
-   tcp        0      0 127.0.0.1:6379              0.0.0.0:*                   LISTEN      3189/stunnel        
+
+   tcp        0      0 127.0.0.1:6379              0.0.0.0:*                   LISTEN      3189/stunnel
    tcp        0      0 127.0.0.1:6380              0.0.0.0:*                   LISTEN      3189/stunnel
    ```
 
 1. Connect to the encrypted Redis node using the local endpoint of the tunnel\.
-   + If no AUTH password was used during ElastiCache for Redis cluster creation, this example uses the redis\-cli to connect to the ElastiCache for Redis server using complete path for redis\-cli, on Amazon Linux: 
+   + If no AUTH password was used during ElastiCache for Redis cluster creation, this example uses the redis\-cli to connect to the ElastiCache for Redis server using complete path for redis\-cli, on Amazon Linux:
 
      ```
      /home/ec2-user/redis-stable/src/redis-cli -h localhost -p 6379
      ```
 
-     If AUTH password was used during Redis cluster creation, this example uses redis\-cli to connect to the Redis server using complete path for redis\-cli, on Amazon Linux: 
+     If AUTH password was used during Redis cluster creation, this example uses redis\-cli to connect to the Redis server using complete path for redis\-cli, on Amazon Linux:
 
      ```
       /home/ec2-user/redis-stable/src/redis-cli -h localhost -p 6379 -a my-secret-password
@@ -293,23 +293,23 @@ To work around this, you can use the `stunnel` command to create an SSL tunnel t
    OR
    + Change directory to redis\-stable and do the following:
 
-     If no AUTH password was used during ElastiCache for Redis cluster creation, this example uses the redis\-cli to connect to the ElastiCache for Redis server using complete path for redis\-cli, on Amazon Linux: 
+     If no AUTH password was used during ElastiCache for Redis cluster creation, this example uses the redis\-cli to connect to the ElastiCache for Redis server using complete path for redis\-cli, on Amazon Linux:
 
      ```
      src/redis-cli -h localhost -p 6379
      ```
 
-     If AUTH password was used during Redis cluster creation, this example uses redis\-cli to connect to the Redis server using complete path for redis\-cli, on Amazon Linux: 
+     If AUTH password was used during Redis cluster creation, this example uses redis\-cli to connect to the Redis server using complete path for redis\-cli, on Amazon Linux:
 
      ```
-     src/redis-cli -h localhost -p 6379 -a my-secret-password	
+     src/redis-cli -h localhost -p 6379 -a my-secret-password
      ```
 
    This example uses Telnet to connect to the Redis server\.
 
    ```
    telnet localhost 6379
-   			
+
    Trying 127.0.0.1...
    Connected to localhost.
    Escape character is '^]'.


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Cleaned up a number of code blocks where the first character for each line was a `$`. When a code block has a `$` as the first character is a `$`, that code can't be directly copy and pasted and executed. Removing the leading `$` should make it easier for end users to cut and paste code snippets from documentation. 

In addition, my IDE settings clean up whitespace at the end of lines.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
